### PR TITLE
Try to check if there's an existing popup open.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Added a guard to `popup-preload` to avoid repeated preload calls to the Popup instance.
+  - This gets reset when the popup is closed.

--- a/src/re_auth0/core.cljs
+++ b/src/re_auth0/core.cljs
@@ -52,6 +52,7 @@
 (defn auth-results-cb
   [on-auth-result on-error]
   (fn [err auth-result]
+    (swap! app-state dissoc :popup-handler)
     (if err
       (if on-error
         (re-frame/dispatch (conj on-error (*js->clj err)))
@@ -102,9 +103,11 @@
 (defn popup-preload
   "Preloads the popup window, to get around blockers"
   []
-  (swap! app-state
-         assoc :popup-handler
-         (.preload (.-popup @web-auth-instance))))
+  (if (:popup-handler @app-state)
+    (js/console.warn "Popup handler already exists. Not creating another.")
+    (swap! app-state
+           assoc :popup-handler
+           (.preload (.-popup @web-auth-instance)))))
 
 
 (defn popup-authorize


### PR DESCRIPTION
Old behaviour: try to preload the popup without any guard.

New behaviour: refuse to preload the popup if the `:popup-handler` key is in app-state and clear it when the auth callback runs.